### PR TITLE
* Removed the unclean Hadnagy's book from the books section.

### DIFF
--- a/content/books.md
+++ b/content/books.md
@@ -25,8 +25,6 @@ Below is intended to be a growing list of books to help you level up those hacke
 			
 [PoC or GTFO Volume 2](https://www.amazon.com/PoC-GTFO-2-Manul-Laphroaig/dp/1593279345/ref=pd_sim_14_1/146-3560802-7928156?_encoding=UTF8&pd_rd_i=1593279345&pd_rd_r=56387d74-8cb6-11e9-9657-19c495c5efa1&pd_rd_w=fVVMm&pd_rd_wg=KupOY&pf_rd_p=90485860-83e9-4fd9-b838-b28a9b7fda30&pf_rd_r=V9V2XCPZMR8JKVVQX2XP&psc=1&refRID=V9V2XCPZMR8JKVVQX2XP)
 			
-[Social Engineering: The Art of Human Hacking](https://www.amazon.com/Social-Engineering-Art-Human-Hacking/dp/0470639539/ref=tmm_pap_swatch_0?_encoding=UTF8&qid=1560305948&sr=1-5)
-			
 [Open Source intelligence Techniques](https://www.amazon.com/Open-Source-Intelligence-Techniques-Information/dp/1984201573/ref=pd_sim_14_10?_encoding=UTF8&pd_rd_i=1984201573&pd_rd_r=7d148a88-8cb8-11e9-a0b4-b1880fe3900a&pd_rd_w=ZyFi6&pd_rd_wg=WYVsC&pf_rd_p=90485860-83e9-4fd9-b838-b28a9b7fda30&pf_rd_r=8YDQWW6DBAMYCW1CJGKR&psc=1&refRID=8YDQWW6DBAMYCW1CJGKR)
 			
 [Black Hat Python](https://www.amazon.com/Black-Hat-Python-Programming-Pentesters/dp/1593275900/ref=pd_sim_14_5/146-3560802-7928156?_encoding=UTF8&pd_rd_i=1593275900&pd_rd_r=b4ea2881-8cb3-11e9-8154-9f1dd9ddcc5a&pd_rd_w=qLy5v&pd_rd_wg=pgywx&pf_rd_p=90485860-83e9-4fd9-b838-b28a9b7fda30&pf_rd_r=GJ8GRDJ37A1JHD8PKAY1&psc=1&refRID=GJ8GRDJ37A1JHD8PKAY1)


### PR DESCRIPTION
Removed "Social Engineering: The Art of Human Hacking" by Christopher Hadnagy from the books section.  Mr Hadnagy was banned from DEF CON in 2022 for code of conduct violations.